### PR TITLE
fix: Remove Girl Develop It from orgs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ Knowing that there are problems isn’t enough. Pick an organization that helps 
 
 - **[Fundclub](http://joinfundclub.com/)**
 
-- **[Girl Develop It](https://www.girldevelopit.com/)**
-
 - **[Good for POC in Tech](http://goodforpocin.tech/)**
 
 - **[Hypatia Software Organization](https://hypatiasoftware.org/)**


### PR DESCRIPTION
In light of recent Girl Develop It controversies about racism and the silencing of its' members, I no longer feel comfortable supporting GDI when I share this wonderful collection of documentation (which is to almost every woman I know). This PR removes them from the main file.

For more information, check out this resource: http://an-open-letter-to-gdi-board.com/

- [x] I have read the [Code of Conduct](code_of_conduct.md) and understand it. By submitting this pull request I agree to follow the Code of Conduct.

@cmho @thejessleigh @sublimemarch

